### PR TITLE
Add ImageHash::hashString() to pass an image blob directly

### DIFF
--- a/src/ImageHash.php
+++ b/src/ImageHash.php
@@ -23,11 +23,10 @@ class ImageHash {
     }
 
     /**
-     * Calculate a perceptual hash of an image.
+     * Calculate a perceptual hash of an image file.
      *
-     * @param  mixed   $resource
-     * @param  integer $size
-     * @return integer
+     * @param  mixed   $resource GD2 resource or filename
+     * @return string
      */
     public function hash($resource)
     {
@@ -43,10 +42,27 @@ class ImageHash {
 
         if ($destroy)
         {
-            imagedestroy($resource);
+            $this->destroyResource($resource);
         }
 
-        return is_int($hash) ? dechex($hash) : $hash;
+        return $this->formatHash($hash);
+    }
+
+    /**
+     * Calculate a perceptual hash of an image string.
+     *
+     * @param  mixed $data Image data
+     * @return string
+     */
+    public function hashString($data)
+    {
+        $resource = $this->createResource($data);
+
+        $hash = $this->implementation->hash($resource);
+
+        $this->destroyResource($resource);
+
+        return $this->formatHash($hash);
     }
 
     /**
@@ -94,7 +110,7 @@ class ImageHash {
     }
 
     /**
-     * Get a file resource.
+     * Get a GD2 resource from file.
      *
      * @param  string   $file
      * @return resource
@@ -106,9 +122,8 @@ class ImageHash {
             return $file;
         }
 
-        try
-        {
-            return imagecreatefromstring(file_get_contents($file));
+        try {
+            return $this->createResource(file_get_contents($file));
         }
         catch (Exception $e)
         {
@@ -116,4 +131,42 @@ class ImageHash {
         }
     }
 
+    /**
+     * Get a GD2 resource from string.
+     *
+     * @param string $data
+     * @return resource
+     */
+    protected function createResource($data)
+    {
+        try
+        {
+            return imagecreatefromstring($data);
+        }
+        catch (Exception $e)
+        {
+            throw new Exception("Unable to create GD2 resource");
+        }
+    }
+
+    /**
+     * Destroy GD2 resource.
+     *
+     * @param resource $resource
+     */
+    protected function destroyResource($resource)
+    {
+        imagedestroy($resource);
+    }
+
+    /**
+     * Format hash in hex.
+     *
+     * @param int $hash
+     * @return string|int
+     */
+    protected function formatHash($hash)
+    {
+        return is_int($hash) ? dechex($hash) : $hash;
+    }
 }

--- a/src/ImageHash.php
+++ b/src/ImageHash.php
@@ -131,15 +131,9 @@ class ImageHash
      */
     protected function loadImageResource($file)
     {
-        if (is_resource($file)) {
-            return $file;
-        }
-
         try {
             return $this->createResource(file_get_contents($file));
-        }
-        catch (Exception $e)
-        {
+        } catch (Exception $e) {
             throw new Exception("Unable to load file: $file");
         }
     }
@@ -152,12 +146,9 @@ class ImageHash
      */
     protected function createResource($data)
     {
-        try
-        {
+        try {
             return imagecreatefromstring($data);
-        }
-        catch (Exception $e)
-        {
+        } catch (Exception $e) {
             throw new Exception("Unable to create GD2 resource");
         }
     }

--- a/tests/ImageHashTest.php
+++ b/tests/ImageHashTest.php
@@ -14,7 +14,7 @@ class ImageHashTest extends PHPUnit_Framework_TestCase
 
     public function testHashStringInvalidFile()
     {
-        $this->expectException(Exception::class);
+        $this->expectException('Exception');
 
         $this->imageHash->hashString('nonImageString');
     }

--- a/tests/ImageHashTest.php
+++ b/tests/ImageHashTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Jenssegers\ImageHash\ImageHash;
+
+class ImageHashTest extends PHPUnit_Framework_TestCase
+{
+    /** @var ImageHash */
+    private $imageHash;
+
+    public function setup()
+    {
+        $this->imageHash = new ImageHash();
+    }
+
+    public function testHashStringInvalidFile()
+    {
+        $this->expectException(Exception::class);
+
+        $this->imageHash->hashString('nonImageString');
+    }
+
+    public function testHashStringSameAsFile()
+    {
+        $path = 'tests/images/forest/forest-low.jpg';
+
+        $this->assertSame($this->imageHash->hash($path), $this->imageHash->hashString(file_get_contents($path)));
+    }
+}

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -1,13 +1,17 @@
 <?php
 
 use Jenssegers\ImageHash\ImageHash;
+use Jenssegers\ImageHash\Implementation;
 use Jenssegers\ImageHash\Implementations\AverageHash;
 use Jenssegers\ImageHash\Implementations\DifferenceHash;
 use Jenssegers\ImageHash\Implementations\PerceptualHash;
 
 class ImageTest extends PHPUnit_Framework_TestCase {
 
-    protected $precision = 10;
+    /** @var Implementation[] */
+    private $hashers;
+
+    private $precision = 10;
 
     public static function setUpBeforeClass()
     {
@@ -50,7 +54,7 @@ class ImageTest extends PHPUnit_Framework_TestCase {
             {
                 foreach ($hashes as $target => $compare)
                 {
-                    if ($target == $image) continue;
+                    if ($target === $image) continue;
 
                     $distance = $imageHash->distance($hash, $compare);
                     $this->assertLessThan($this->precision, $distance, "[" . get_class($hasher) . "] $image ($hash) ^ $target ($compare)");
@@ -84,7 +88,7 @@ class ImageTest extends PHPUnit_Framework_TestCase {
             {
                 foreach ($hashes as $target => $compare)
                 {
-                    if ($target == $image) continue;
+                    if ($target === $image) continue;
 
                     $distance = $imageHash->distance($hash, $compare);
                     $this->assertGreaterThan($this->precision, $distance, "[" . get_class($hasher) . "] $image ($hash) ^ $target ($compare)");
@@ -109,7 +113,7 @@ class ImageTest extends PHPUnit_Framework_TestCase {
             {
                 foreach ($images as $target)
                 {
-                    if ($target == $image) continue;
+                    if ($target === $image) continue;
 
                     $distance = $imageHash->compare($image, $target);
                     $this->assertLessThan($this->precision, $distance, "[" . get_class($hasher) . "] $image <=> $target");
@@ -129,7 +133,7 @@ class ImageTest extends PHPUnit_Framework_TestCase {
             {
                 foreach ($images as $target)
                 {
-                    if ($target == $image) continue;
+                    if ($target === $image) continue;
 
                     $distance = $imageHash->compare($image, $target);
                     $this->assertGreaterThan($this->precision, $distance, "[" . get_class($hasher) . "] $image <=> $target");


### PR DESCRIPTION
Reasoning: `hash()` already takes a resource, so I could just create a resource. For testing reasons it would be nicer still to be able to just pass a path and then let the service create the resource, so one can more easily mock the `ImageHash` object for unit testing.