### PR TITLE
Fix hexadecimal to decimal conversion for negative  hashes

### DIFF
--- a/src/ImageHash.php
+++ b/src/ImageHash.php
@@ -130,6 +130,21 @@ class ImageHash
     }
 
     /**
+     * Convert hexadecimal to signed decimal.
+     *
+     * @param string $hex
+     * @return int
+     */
+    public function hexdec($hex)
+    {
+        if (strlen($hex) == 16 && hexdec($hex[0]) > 8) {
+            return unpack('J', hex2bin($hex))[1];
+        }
+
+        return hexdec($hex);
+    }
+
+    /**
      * Get a GD2 resource from file.
      *
      * @param  string $file
@@ -178,20 +193,5 @@ class ImageHash
     protected function formatHash($hash)
     {
         return $this->mode === static::HEXADECIMAL ? dechex($hash) : $hash;
-    }
-
-    /**
-     * Convert hexadecimal to signed decimal.
-     *
-     * @param string $hex
-     * @return int
-     */
-    protected function hexdec($hex)
-    {
-        if (strlen($hex) == 16 && hexdec($hex[0]) > 8) {
-            return unpack('J', hex2bin($hex))[1];
-        }
-
-        return hexdec($hex);
     }
 }

--- a/src/ImageHash.php
+++ b/src/ImageHash.php
@@ -113,8 +113,8 @@ class ImageHash
             }
         } else {
             if ($this->mode === self::HEXADECIMAL) {
-                $hash1 = hexdec($hash1);
-                $hash2 = hexdec($hash2);
+                $hash1 = $this->hexdec($hash1);
+                $hash2 = $this->hexdec($hash2);
             }
 
             $dh = 0;
@@ -178,5 +178,20 @@ class ImageHash
     protected function formatHash($hash)
     {
         return $this->mode === static::HEXADECIMAL ? dechex($hash) : $hash;
+    }
+
+    /**
+     * Convert hexadecimal to signed decimal.
+     *
+     * @param string $hex
+     * @return int
+     */
+    protected function hexdec($hex)
+    {
+        if (strlen($hex) == 16 && hexdec($hex[0]) > 8) {
+            return unpack('J', hex2bin($hex))[1];
+        }
+
+        return hexdec($hex);
     }
 }

--- a/src/ImageHash.php
+++ b/src/ImageHash.php
@@ -138,7 +138,8 @@ class ImageHash
     public function hexdec($hex)
     {
         if (strlen($hex) == 16 && hexdec($hex[0]) > 8) {
-            return unpack('J', hex2bin($hex))[1];
+            list($higher, $lower) = array_values(unpack('N2', hex2bin($hex)));
+            return $higher << 32 | $lower;
         }
 
         return hexdec($hex);

--- a/tests/ImageHashTest.php
+++ b/tests/ImageHashTest.php
@@ -31,4 +31,14 @@ class ImageHashTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame($this->imageHash->hash($path), $this->imageHash->hashFromString(file_get_contents($path)));
     }
+
+    public function testDistanceOfNegativeHashes()
+    {
+        $imageHash = new ImageHash(null, ImageHash::HEXADECIMAL);
+        $hash1 = 'ffffffffffffffff'; // -1
+        $hash2 = 'fffffffffffffff0'; // -16
+
+        $distance = $imageHash->distance($hash1, $hash2);
+        $this->assertEquals(4, $distance);
+    }
 }

--- a/tests/ImageHashTest.php
+++ b/tests/ImageHashTest.php
@@ -32,6 +32,18 @@ class ImageHashTest extends PHPUnit_Framework_TestCase
         $this->assertSame($this->imageHash->hash($path), $this->imageHash->hashFromString(file_get_contents($path)));
     }
 
+    public function testHexdecForNegativeIntegers()
+    {
+        // native hexdec dechex conversion working for positive integers
+        $this->assertEquals(1, hexdec(dechex(1)));
+        // but not working for negative
+        $this->assertNotEquals(-1, hexdec(dechex(-1)));
+
+        // custom hexdec implementation works for both
+        $this->assertEquals(1, $this->imageHash->hexdec(dechex(1)));
+        $this->assertEquals(-1, $this->imageHash->hexdec(dechex(-1)));
+    }
+
     public function testDistanceOfNegativeHashes()
     {
         $imageHash = new ImageHash(null, ImageHash::HEXADECIMAL);


### PR DESCRIPTION
For negative integers dechex and hexdec conversion returns differtent from original value
```php
-1 != hexdec(dechex(-1)); // true
```

This pull request fixes this trouble