### PR TITLE
Consistently build 16 char hex. Solves issue of leading zeros.

### DIFF
--- a/src/ImageHash.php
+++ b/src/ImageHash.php
@@ -193,13 +193,12 @@ class ImageHash
      */
     protected function formatHash($hash)
     {
-        if($this->mode === static::HEXADECIMAL){
+        if ($this->mode === static::HEXADECIMAL) {
             $hex = '';
             //Shortening the string prevents any issues with php casting the string to an integer it cannot manage.
-            $strings = str_split($hash,8);
-            foreach($strings as $string)
-            {
-                $hex .= str_pad(base_convert($string,2, 16) , 2 , "0" , STR_PAD_LEFT);
+            $strings = str_split($hash, 8);
+            foreach($strings as $string) {
+                $hex .= str_pad(base_convert($string, 2, 16), 2, "0" , STR_PAD_LEFT);
             }
             return $hex;
         }else{

--- a/src/ImageHash.php
+++ b/src/ImageHash.php
@@ -193,6 +193,17 @@ class ImageHash
      */
     protected function formatHash($hash)
     {
-        return $this->mode === static::HEXADECIMAL ? dechex($hash) : $hash;
+        if($this->mode === static::HEXADECIMAL){
+            $hex = '';
+            //Shortening the string prevents any issues with php casting the string to an integer it cannot manage.
+            $strings = str_split($hash,8);
+            foreach($strings as $string)
+            {
+                $hex .= str_pad(base_convert($string,2, 16) , 2 , "0" , STR_PAD_LEFT);
+            }
+            return $hex;
+        }else{
+            return $hash;
+        }
     }
 }

--- a/src/ImageHash.php
+++ b/src/ImageHash.php
@@ -197,11 +197,11 @@ class ImageHash
             $hex = '';
             //Shortening the string prevents any issues with php casting the string to an integer it cannot manage.
             $strings = str_split($hash, 8);
-            foreach($strings as $string) {
-                $hex .= str_pad(base_convert($string, 2, 16), 2, "0" , STR_PAD_LEFT);
+            foreach ($strings as $string) {
+                $hex .= str_pad(base_convert($string, 2, 16), 2, "0", STR_PAD_LEFT);
             }
             return $hex;
-        }else{
+        } else {
             return $hash;
         }
     }

--- a/src/Implementations/DifferenceHash.php
+++ b/src/Implementations/DifferenceHash.php
@@ -34,7 +34,7 @@ class DifferenceHash implements Implementation
                 // http://www.hackerfactor.com/blog/index.php?/archives/529-Kind-of-Like-That.html
                 if ($left > $right) {
                     $hash .= '1';
-                }else{
+                } else {
                     $hash .= '0';
                 }
                 // Prepare the next loop.

--- a/src/Implementations/DifferenceHash.php
+++ b/src/Implementations/DifferenceHash.php
@@ -19,8 +19,7 @@ class DifferenceHash implements Implementation
         $resized = imagecreatetruecolor($width, $heigth);
         imagecopyresampled($resized, $resource, 0, 0, 0, 0, $width, $heigth, imagesx($resource), imagesy($resource));
 
-        $hash = 0;
-        $one = 1;
+        $hash = ''; // Binary as a string to avoid php interpreting as integer later
         for ($y = 0; $y < $heigth; $y++) {
             // Get the pixel value for the leftmost pixel.
             $rgb = imagecolorsforindex($resized, imagecolorat($resized, 0, $y));
@@ -34,12 +33,12 @@ class DifferenceHash implements Implementation
                 // Each hash bit is set based on whether the left pixel is brighter than the right pixel.
                 // http://www.hackerfactor.com/blog/index.php?/archives/529-Kind-of-Like-That.html
                 if ($left > $right) {
-                    $hash |= $one;
+                    $hash .= '1';
+                }else{
+                    $hash .= '0';
                 }
-
                 // Prepare the next loop.
                 $left = $right;
-                $one = $one << 1;
             }
         }
 


### PR DESCRIPTION
Solution to this issue:
https://github.com/jenssegers/imagehash/issues/28
I was getting abbreviated hashes which appeared to be caused by leading zeros being dropped.
This string only solution solves. Tested on 40,000 images twice.