### PR TITLE
Update to the current/maintained repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0|^7.0",
-        "satooshi/php-coveralls": "^2.0"
+        "php-coveralls/php-coveralls": "^2.0"
     },
     "suggest": {
         "ext-gmp": "GMP results in faster comparisons",


### PR DESCRIPTION
This change updates a dependency that doesn't support PHP 8.X by changing to the proper/current repo. The namespace changed and the old one is deprecated and won't support PHP8.