### PR TITLE
Upgrade minimum PHP version and dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,18 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ["7.1", "7.2", "7.3", "7.4", "8.0"]
-        extensions: ["gd", "imagick"]
-    name: PHP ${{ matrix.php-versions }} - ${{ matrix.extensions }}
+        php-version: ["8.1", "8.2", "8.3"]
+        extension: ["gd, :imagick", "imagick, :gd"] # the ':" prefix is used to unload the other extension
+    name: PHP ${{ matrix.php-version }} - ${{ matrix.extension }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
-          extensions: ${{ matrix.extensions }}
+          php-version: ${{ matrix.php-version }}
+          extensions: ${{ matrix.extension }}
           coverage: xdebug
 
       - name: Check environment
@@ -27,15 +27,15 @@ jobs:
           composer --version
 
       - name: Get composer cache directory
-        id: composercache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
-          path: ${{ steps.composercache.outputs.dir }}
-          key: ${{ matrix.os }}-composer-${{ matrix.php-versions }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ matrix.os }}-composer-${{ matrix.php-versions }}-
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ matrix.os }}-composer-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ matrix.os }}-composer-${{ matrix.php-version }}-
 
       - name: Install dependencies
         run: composer install --prefer-dist
@@ -49,8 +49,8 @@ jobs:
       - name: Upload coverage to Codecov
         env: 
           OS: ${{ matrix.os }}
-          PHP: ${{ matrix.php-versions }}
-        uses: codecov/codecov-action@v1
+          PHP: ${{ matrix.php-version }}
+        uses: codecov/codecov-action@v3
         with:
            file: build/logs/clover.xml
            env_vars: OS,PHP

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 composer.lock
+.phpunit.cache
 .phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This code was inspired/based on:
 Requirements
 ------------
 
- - PHP 7.1 or higher
+ - PHP 8.1 or higher
  - The [gd](http://php.net/manual/en/book.image.php) or [imagick](http://php.net/manual/en/book.imagick.php) extension
  - Optionally, install the [GMP](http://php.net/manual/en/book.gmp.php) extension for faster fingerprint comparisons
 

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0",
-        "intervention/image": "^2.4"
+        "php": "^8.1",
+        "intervention/image": "^3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7|^8|^9",
+        "phpunit/phpunit": "^10",
         "php-coveralls/php-coveralls": "^2.0"
     },
     "suggest": {

--- a/docker/gd.Dockerfile
+++ b/docker/gd.Dockerfile
@@ -1,8 +1,10 @@
-ARG PHP_VERSION=7.2
-ARG COMPOSER_VERSION=1.8
+ARG PHP_VERSION=8.1
+ARG COMPOSER_VERSION=2
 
-FROM composer:${COMPOSER_VERSION}
+FROM composer:${COMPOSER_VERSION} as composer
 FROM php:${PHP_VERSION}-cli
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 RUN apt-get update && \
     apt-get install libpng-dev libjpeg-dev --no-install-recommends -qy && \

--- a/docker/gmp.Dockerfile
+++ b/docker/gmp.Dockerfile
@@ -1,8 +1,10 @@
-ARG PHP_VERSION=7.2
-ARG COMPOSER_VERSION=1.8
+ARG PHP_VERSION=8.1
+ARG COMPOSER_VERSION=2
 
-FROM composer:${COMPOSER_VERSION}
+FROM composer:${COMPOSER_VERSION} as composer
 FROM php:${PHP_VERSION}-cli
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 RUN apt-get update && \
     apt-get install libgmp-dev libpng-dev libjpeg-dev --no-install-recommends -qy && \

--- a/docker/imagick.Dockerfile
+++ b/docker/imagick.Dockerfile
@@ -1,11 +1,14 @@
-ARG PHP_VERSION=7.2
-ARG COMPOSER_VERSION=1.8
+ARG PHP_VERSION=8.1
+ARG COMPOSER_VERSION=2
 
-FROM composer:${COMPOSER_VERSION}
+FROM composer:${COMPOSER_VERSION} as composer
 FROM php:${PHP_VERSION}-cli
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 RUN apt-get update && \
     apt-get install libmagickwand-dev --no-install-recommends -qy && \
     rm -rf /var/lib/apt/lists/* && \
     ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h && \
-    pecl install imagick && docker-php-ext-enable imagick
+    pecl install imagick && \
+    docker-php-ext-enable imagick

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,21 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="tests/bootstrap.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="pHash">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="false">
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="tests/bootstrap.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="pHash">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Hash.php
+++ b/src/Hash.php
@@ -11,14 +11,14 @@ class Hash implements JsonSerializable
      *
      * @var string
      */
-    protected $binaryValue;
+    protected string $binaryValue;
 
     /**
      * Hash will be split in several integers if longer than PHP_INT_SIZE
      *
      * @var int[]|null
      */
-    protected $integers = null;
+    protected ?array $integers = null;
 
     /**
      * @param string $binaryValue
@@ -35,7 +35,7 @@ class Hash implements JsonSerializable
      *
      * @return self
      */
-    public static function fromBits($bits): self
+    public static function fromBits(array|string $bits): self
     {
         if (\is_array($bits)) {
             $bits = implode('', $bits);

--- a/src/ImageHash.php
+++ b/src/ImageHash.php
@@ -1,5 +1,7 @@
 <?php namespace Jenssegers\ImageHash;
 
+use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
 use Intervention\Image\Image;
 use Intervention\Image\ImageManager;
 use Jenssegers\ImageHash\Implementations\DifferenceHash;
@@ -7,15 +9,9 @@ use RuntimeException;
 
 class ImageHash
 {
-    /**
-     * @var Implementation
-     */
-    protected $implementation;
+    protected Implementation $implementation;
 
-    /**
-     * @var Image
-     */
-    private $driver;
+    private ImageManager $driver;
 
     public function __construct(
         Implementation $implementation = null,
@@ -30,9 +26,9 @@ class ImageHash
      * @param mixed $image
      * @return Hash
      */
-    public function hash($image): Hash
+    public function hash(mixed $image): Hash
     {
-        $image = $this->driver->make($image);
+        $image = $this->driver->read($image);
 
         return $this->implementation->hash($image);
     }
@@ -43,7 +39,7 @@ class ImageHash
      * @param mixed $resource2
      * @return int
      */
-    public function compare($resource1, $resource2): int
+    public function compare(mixed $resource1, mixed $resource2): int
     {
         $hash1 = $this->hash($resource1);
         $hash2 = $this->hash($resource2);
@@ -58,7 +54,7 @@ class ImageHash
 
     protected function createResource(string $data): Image
     {
-        return $this->driver->make($data);
+        return $this->driver->read($data);
     }
 
     protected function defaultImplementation(): Implementation
@@ -69,11 +65,11 @@ class ImageHash
     protected function defaultDriver(): ImageManager
     {
         if (extension_loaded('imagick')) {
-            return new ImageManager(['driver' => 'imagick']);
+            return new ImageManager(new ImagickDriver());
         }
-        
+
         if (extension_loaded('gd')) {
-            return new ImageManager(['driver' => 'gd']);
+            return new ImageManager(new GdDriver());
         }
 
         throw new RuntimeException('Please install GD or ImageMagick');

--- a/src/Implementations/AverageHash.php
+++ b/src/Implementations/AverageHash.php
@@ -6,10 +6,7 @@ use Jenssegers\ImageHash\Implementation;
 
 class AverageHash implements Implementation
 {
-    /**
-     * @var int
-     */
-    protected $size;
+    protected int $size;
 
     public function __construct(int $size = 8)
     {
@@ -25,7 +22,7 @@ class AverageHash implements Implementation
         $pixels = [];
         for ($y = 0; $y < $this->size; $y++) {
             for ($x = 0; $x < $this->size; $x++) {
-                $rgb = $resized->pickColor($x, $y);
+                $rgb = $resized->pickColor($x, $y)->toArray();
                 $pixels[] = (int) floor(($rgb[0] * 0.299) + ($rgb[1] * 0.587) + ($rgb[2] * 0.114));
             }
         }

--- a/src/Implementations/BlockHash.php
+++ b/src/Implementations/BlockHash.php
@@ -19,15 +19,9 @@ class BlockHash implements Implementation
      */
     const QUICK = 'quick';
 
-    /**
-     * @var string
-     */
-    protected $mode;
+    protected string $mode;
 
-    /**
-     * @var int
-     */
-    protected $size;
+    protected int $size;
 
     public function __construct(int $size = 16, $mode = self::PRECISE)
     {
@@ -54,8 +48,8 @@ class BlockHash implements Implementation
 
     private function even(Image $image): Hash
     {
-        $width = $image->getWidth();
-        $height = $image->getHeight();
+        $width = $image->width();
+        $height = $image->height();
         $blocksizeX = (int) floor($width / $this->size);
         $blocksizeY = (int) floor($height / $this->size);
 
@@ -69,7 +63,7 @@ class BlockHash implements Implementation
                     for ($ix = 0; $ix < $blocksizeX; $ix++) {
                         $cx = $x * $blocksizeX + $ix;
                         $cy = $y * $blocksizeY + $iy;
-                        $rgb = $image->pickColor($cx, $cy);
+                        $rgb = $image->pickColor($cx, $cy)->toArray();
                         $value += $rgb[0] + $rgb[1] + $rgb[2];
                     }
                 }
@@ -83,8 +77,8 @@ class BlockHash implements Implementation
 
     private function uneven(Image $image): Hash
     {
-        $imageWidth = $image->getWidth();
-        $imageHeight = $image->getHeight();
+        $imageWidth = $image->width();
+        $imageHeight = $image->height();
         $evenX = $imageWidth % $this->size === 0;
         $evenY = $imageHeight % $this->size === 0;
         $blockWidth = $imageWidth / $this->size;
@@ -103,7 +97,7 @@ class BlockHash implements Implementation
                 $weightTop = 1;
                 $weightBottom = 0;
             } else {
-                $yMod = ($y + 1) % $blockHeight;
+                $yMod = fmod($y + 1, $blockHeight);
                 $yFrac = $yMod - (int) floor($yMod);
                 $yInt = $yMod - $yFrac;
 
@@ -120,7 +114,7 @@ class BlockHash implements Implementation
             }
 
             for ($x = 0; $x < $imageWidth; $x++) {
-                $rgb = $image->pickColor($x, $y);
+                $rgb = $image->pickColor($x, $y)->toArray();
                 $value = $rgb[0] + $rgb[1] + $rgb[2];
 
                 if ($evenX) {
@@ -128,7 +122,7 @@ class BlockHash implements Implementation
                     $weightLeft = 1;
                     $weightRight = 0;
                 } else {
-                    $xMod = ($x + 1) % $blockWidth;
+                    $xMod = fmod($x + 1, $blockWidth);
                     $xFrac = $xMod - (int) floor($xMod);
                     $xInt = $xMod - $xFrac;
 

--- a/src/Implementations/DifferenceHash.php
+++ b/src/Implementations/DifferenceHash.php
@@ -6,10 +6,7 @@ use Jenssegers\ImageHash\Implementation;
 
 class DifferenceHash implements Implementation
 {
-    /**
-     * @var int
-     */
-    protected $size;
+    protected int $size;
 
     public function __construct(int $size = 8)
     {
@@ -28,12 +25,12 @@ class DifferenceHash implements Implementation
         $bits = [];
         for ($y = 0; $y < $height; $y++) {
             // Get the pixel value for the leftmost pixel.
-            $rgb = $resized->pickColor(0, $y);
+            $rgb = $resized->pickColor(0, $y)->toArray();
             $left = (int) floor(($rgb[0] * 0.299) + ($rgb[1] * 0.587) + ($rgb[2] * 0.114));
 
             for ($x = 1; $x < $width; $x++) {
                 // Get the pixel value for each pixel starting from position 1.
-                $rgb = $resized->pickColor($x, $y);
+                $rgb = $resized->pickColor($x, $y)->toArray();
                 $right = (int) floor(($rgb[0] * 0.299) + ($rgb[1] * 0.587) + ($rgb[2] * 0.114));
 
                 // Each hash bit is set based on whether the left pixel is brighter than the right pixel.

--- a/src/Implementations/PerceptualHash.php
+++ b/src/Implementations/PerceptualHash.php
@@ -17,15 +17,9 @@ class PerceptualHash implements Implementation
      */
     const MEDIAN = 'median';
 
-    /**
-     * @var int
-     */
-    protected $size;
+    protected int $size;
 
-    /**
-     * @var string
-     */
-    protected $comparisonMethod;
+    protected string $comparisonMethod;
 
     public function __construct(int $size = 32, string $comparisonMethod = self::AVERAGE)
     {
@@ -49,7 +43,7 @@ class PerceptualHash implements Implementation
 
         for ($y = 0; $y < $this->size; $y++) {
             for ($x = 0; $x < $this->size; $x++) {
-                $rgb = $resized->pickColor($x, $y);
+                $rgb = $resized->pickColor($x, $y)->toArray();
                 $row[$x] = (int) floor(($rgb[0] * 0.299) + ($rgb[1] * 0.587) + ($rgb[2] * 0.114));
             }
             $rows[$y] = $this->calculateDCT($row);

--- a/tests/ImageHashTest.php
+++ b/tests/ImageHashTest.php
@@ -1,15 +1,12 @@
 <?php
 
-use Intervention\Image\Exception\NotReadableException;
+use Intervention\Image\Exceptions\DecoderException;
 use Jenssegers\ImageHash\ImageHash;
 use PHPUnit\Framework\TestCase;
 
 class ImageHashTest extends TestCase
 {
-    /**
-     * @var ImageHash
-     */
-    private $imageHash;
+    private ImageHash $imageHash;
 
     public function setup(): void
     {
@@ -18,7 +15,7 @@ class ImageHashTest extends TestCase
 
     public function testHashInvalidFile()
     {
-        $this->expectException(NotReadableException::class);
+        $this->expectException(DecoderException::class);
 
         $this->imageHash->hash('nonImageString');
     }

--- a/tests/ImplementationTest.php
+++ b/tests/ImplementationTest.php
@@ -6,22 +6,17 @@ use Jenssegers\ImageHash\Implementations\AverageHash;
 use Jenssegers\ImageHash\Implementations\BlockHash;
 use Jenssegers\ImageHash\Implementations\DifferenceHash;
 use Jenssegers\ImageHash\Implementations\PerceptualHash;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ImplementationTest extends TestCase
 {
-    /**
-     * @var int
-     */
-    private $threshold = 10;
+    private int $threshold = 10;
 
-    /**
-     * @var bool
-     */
-    private $debug = true;
+    private bool $debug = true;
 
-    public function provideImplementations()
-    {
+    public static function provideImplementations(): array
+	{
         return [
             [new AverageHash()],
             [new DifferenceHash()],
@@ -32,26 +27,17 @@ class ImplementationTest extends TestCase
         ];
     }
 
-    /**
-     * @return array
-     */
-    protected function getSimilarImages()
-    {
+    protected function getSimilarImages(): array
+	{
         return glob(__DIR__ . '/images/forest/*');
     }
 
-    /**
-     * @return array
-     */
-    protected function getDifferentImages()
-    {
+    protected function getDifferentImages(): array
+	{
         return glob(__DIR__ . '/images/office/*');
     }
 
-    /**
-     * @dataProvider provideImplementations
-     * @param Implementation $implementation
-     */
+	#[DataProvider('provideImplementations')]
     public function testEqualHashes(Implementation $implementation)
     {
         $sum = 0;
@@ -81,10 +67,7 @@ class ImplementationTest extends TestCase
         $this->debug("[" . get_class($implementation) . "] Total score: $sum");
     }
 
-    /**
-     * @dataProvider provideImplementations
-     * @param Implementation $implementation
-     */
+	#[DataProvider('provideImplementations')]
     public function testDifferentHashes(Implementation $implementation)
     {
         $sum = 0;
@@ -114,8 +97,7 @@ class ImplementationTest extends TestCase
         $this->debug("[" . get_class($implementation) . "] Total score: $sum");
     }
 
-    protected function debug($message)
-    {
+    protected function debug(string $message): void {
         if ($this->debug) {
             echo PHP_EOL . $message;
         }


### PR DESCRIPTION
I got a bit carried away due the fact that the new `intervention/image` version requires PHP 8.1.

Closes #85 

## This PR contains the following changes:
- Upgrade `intervention/image` to major version 3
- Upgrade `phpunit/phpunit` to major version 10
- Make properties typed
- Fix a deprecation warning when using a float value as modulo divisor
- Bump the minimum PHP version to 8.1
- Bump Github Actions to their supported versions

---

This is how it went:

https://github.com/jenssegers/imagehash/assets/3403851/87ef5f46-5868-4219-9bde-a85933b892a9

