### PR TITLE
Remove implicitly nullable parameter declarations

### DIFF
--- a/src/ImageHash.php
+++ b/src/ImageHash.php
@@ -14,8 +14,8 @@ class ImageHash
     private ImageManager $driver;
 
     public function __construct(
-        Implementation $implementation = null,
-        ImageManager $driver = null
+        ?Implementation $implementation = null,
+        ?ImageManager $driver = null
     ) {
         $this->implementation = $implementation ?: $this->defaultImplementation();
         $this->driver = $driver ?: $this->defaultDriver();


### PR DESCRIPTION
Implicitly nullable parameter declarations are [deprecated from PHP 8.4 on](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated) and will be removed in PHP 9. This project uses them in one function only, which is fixed by this PR. 

How to reproduce:
```
> docker run --rm -v .:/app "php:8.4-rc-cli" find /app -type f -name "*.php" -exec php -d error_reporting=32765 -l {} \; | grep -v 'No syntax errors detected'
Deprecated: Jenssegers\ImageHash\ImageHash::__construct(): Implicitly marking parameter $implementation as nullable is deprecated, the explicit nullable type must be used instead in /app/src/ImageHash.php on line 16
Deprecated: Jenssegers\ImageHash\ImageHash::__construct(): Implicitly marking parameter $driver as nullable is deprecated, the explicit nullable type must be used instead in /app/src/ImageHash.php on line 16
```

Note: Not fixed are deprecated features in the test dependencies (namely PhpCoveralls). 