### PR TITLE
chore(php): add support for PHP 8.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ["8.1", "8.2", "8.3"]
+        php-version: ["8.1", "8.2", "8.3", "8.4"]
         extension: ["gd, :imagick", "imagick, :gd"] # the ':" prefix is used to unload the other extension
     name: PHP ${{ matrix.php-version }} - ${{ matrix.extension }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ["8.1", "8.2", "8.3", "8.4"]
+        php-version: ["8.2", "8.3", "8.4"]
         extension: ["gd, :imagick", "imagick, :gd"] # the ':" prefix is used to unload the other extension
     name: PHP ${{ matrix.php-version }} - ${{ matrix.extension }}
     steps:

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "intervention/image": "^3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11",
+        "phpunit/phpunit": "^11.5.3",
         "php-coveralls/php-coveralls": "^2.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "intervention/image": "^3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10",
+        "phpunit/phpunit": "^11",
         "php-coveralls/php-coveralls": "^2.0"
     },
     "suggest": {

--- a/src/ImageHash.php
+++ b/src/ImageHash.php
@@ -14,8 +14,8 @@ class ImageHash
     private ImageManager $driver;
 
     public function __construct(
-        Implementation $implementation = null,
-        ImageManager $driver = null
+        ?Implementation $implementation = null,
+        ?ImageManager $driver = null
     ) {
         $this->implementation = $implementation ?: $this->defaultImplementation();
         $this->driver = $driver ?: $this->defaultDriver();


### PR DESCRIPTION
This adds 8.4 as a test target and removes the implicitly nullable parameter declarations. It's an extension of #87.

Also drop 8.1 support and upgrade PHPUnit to 11.x.